### PR TITLE
Fix serialization of values in base_table_section

### DIFF
--- a/mztab_m_io/model/section/base_table_section.py
+++ b/mztab_m_io/model/section/base_table_section.py
@@ -103,7 +103,8 @@ class BaseTableSection(MzTabBaseModel, CustomSerializer):
                         )
                         row.append(val)
                     else:
-                        self.serialize_value(val)
+                        val = self.serialize_value(val)
+                        row.append(val)
                 else:
                     if isinstance(val, list):
                         row.extend(self.serialize_value(val))


### PR DESCRIPTION
Serializing the MzTabM model to tsv format and parsing it led to empty parsed SML tables even though the output contained the SML tables.

The "parse_table_section" couldn't parse the SML table since the header contained one entry more than the lines afterwards. Upon closer inspection of the files I noticed the URI column was missing in the serialized output.

During debugging I noticed that the serialized value for the uri field is silently being dropped instead of added to the row list. This pull request fixes this and leads to correct mztab-m serialized files again