### PR TITLE
Add missing default None for CV

### DIFF
--- a/mztab_m_io/model/section/mtd.py
+++ b/mztab_m_io/model/section/mtd.py
@@ -464,7 +464,7 @@ class Metadata(MzTabSerializableModel, CustomSerializer):
                 validation_policy=ValidationPolicy(required=True, minimum=1)
             ).model_dump(),
         ),
-    ]
+    ] = None
 
     small_molecule_quantification_unit: Annotated[
         Optional[Parameter],

--- a/tests/mztabm/test_metadata.py
+++ b/tests/mztabm/test_metadata.py
@@ -1,0 +1,6 @@
+from mztab_m_io.model import Metadata
+
+
+def test_empty_instantiation():
+    instance = Metadata()
+    assert instance.cv is None


### PR DESCRIPTION
The CV parameter is the only parameter of the Metadata table without a default `None` value.
Because of this, `cv` needs to be specified, else a validation error occurs when creating a Metadata instance.

i.e. previous behaviour:
```python
>>> meta = Metadata()
pydantic_core._pydantic_core.ValidationError: 1 validation error for Metadata
cv
  Field required [type=missing, input_value=OrderedDict({'mzTab-versi...ion_reliability': None}), input_type=OrderedDict]
    For further information visit https://errors.pydantic.dev/2.13/v/missing
```
and only instantiates correctly with:
```python
>>> meta = Metadata(cv=[CV()])
```

behaviour with fix:
```python
>>> meta = Metadata()
>>> meta.cv
None
```