### PR TITLE
Patch dictionary load bug

### DIFF
--- a/mztab_m_io/__init__.py
+++ b/mztab_m_io/__init__.py
@@ -207,7 +207,7 @@ def load_from_dict(data: Dict[str, Any]) -> MzTabMLoadResult:
     """
     result = MzTabMLoadResult(success=False, messages=[], source_format="json")
     try:
-        mztabm = MzTabM.from_dict(data, context=result)
+        mztabm, _serialization_context = MzTabM.from_dict(data, context=result)
         result.mztabm = mztabm
         result.success = True
     except ValidationError as ex:

--- a/tests/mztabm/test_mztabm.py
+++ b/tests/mztabm/test_mztabm.py
@@ -2,7 +2,6 @@ import json
 import shutil
 from pathlib import Path
 
-import pytest
 import mztab_m_io as mztabm
 
 

--- a/tests/mztabm/test_mztabm.py
+++ b/tests/mztabm/test_mztabm.py
@@ -2,6 +2,7 @@ import json
 import shutil
 from pathlib import Path
 
+import pytest
 import mztab_m_io as mztabm
 
 
@@ -57,8 +58,9 @@ def test_load_from_dict():
     file_path = "tests/data/example/example.json"
     with Path(file_path).open() as f:
         mztabm_dict = json.load(f)
-    mztabm_model = mztabm.load_from_dict(mztabm_dict)
-    assert mztabm_model
+    result = mztabm.load_from_dict(mztabm_dict)
+    assert result.mztabm is not None
+    assert isinstance(result.mztabm, mztabm.MzTabM)
 
 
 def test_write_01():


### PR DESCRIPTION
`MzTabM.from_dict` returns a tuple. In the `read_from_dict` function, this tuple is assigned directly to `MzTabMLoadResult.mztabm` which leads to an enormous validation error message.